### PR TITLE
feat: add Attack Analytics tools (incidents, events, stats, insights)

### DIFF
--- a/src/cwaf_external_mcp/mcp_tools/cwaf_tools.py
+++ b/src/cwaf_external_mcp/mcp_tools/cwaf_tools.py
@@ -24,6 +24,13 @@ from fastmcp import Context
 from cwaf_external_mcp.context.context_manager import context_manager
 from cwaf_external_mcp.httpclient.aiohttp_client import get_async_client
 from cwaf_external_mcp.model.api_error import ApiError
+from cwaf_external_mcp.model.attack_analytics_dto import (
+    AttackAnalyticsResponse,
+    Incident,
+    Event,
+    IncidentStats,
+    InsightsDataApi,
+)
 from cwaf_external_mcp.model.cwaf_error_response import CWAFErrorResponse
 from cwaf_external_mcp.model.cwaf_response import CWAFResponse, Meta
 from cwaf_external_mcp.model.policy_dto import Policy, PolicySettings, PolicyConfig
@@ -48,6 +55,9 @@ BASE_POLICIES_URL = os.environ.get(
     "BASE_POLICIES_URL", "https://api.imperva.com/policies"
 )
 BASE_RULES_URL = os.environ.get("BASE_RULES_URL", "https://my.imperva.com/api/prov")
+BASE_ANALYTICS_URL = os.environ.get(
+    "BASE_ANALYTICS_URL", "https://api.imperva.com/analytics"
+)
 
 
 async def get_rules_api(
@@ -569,6 +579,198 @@ def get_default_policy_config_from_response(policy_config: list) -> list[PolicyC
         )
         for r in policy_config
     ]
+
+
+async def invoke_analytics_get_request(
+    url: str,
+    params: dict,
+    context: Optional[Context] = None,
+) -> AttackAnalyticsResponse | CWAFErrorResponse:
+    """Invoke an HTTP GET request to the Attack Analytics API (non-paginated)."""
+
+    MCP_HEADER_NAME = os.environ.get("MCP_HEADER_NAME", "x-mcp-imperva")
+    MCP_HEADER_VALUE = os.environ.get("MCP_HEADER_VALUE", "cwaf-external-mcp")
+    HEADERS = {
+        "Content-Type": "application/json",
+        MCP_HEADER_NAME: MCP_HEADER_VALUE,
+    }
+    HEADERS.update(context_manager.get_headers())
+
+    try:
+        logger.info("calling %s, with params %s", url, params)
+        response = await get_async_client().get(url, headers=HEADERS, params=params)
+        data = await response.json(content_type=None)
+        logger.info("response from %s: %s", url, data)
+        if response.status != 200:
+            if context:
+                await context.error(data)
+            error_detail = data.get("message", str(data)) if isinstance(data, dict) else str(data)
+            return CWAFErrorResponse(
+                errors=[
+                    ApiError(
+                        status=response.status,
+                        title="Attack Analytics API error",
+                        detail=error_detail,
+                    )
+                ]
+            )
+        return AttackAnalyticsResponse(data=data)
+    except Exception:
+        logger.exception("Error invoking %s with params %s", url, params)
+        return CWAFErrorResponse(
+            errors=[
+                ApiError(
+                    status=500,
+                    title="internal error",
+                    detail="",
+                )
+            ]
+        )
+
+
+async def get_incidents_api(
+    account_id: Union[int, str],
+    context: Optional[Context] = None,
+    from_timestamp: Optional[Union[int, str]] = None,
+    to_timestamp: Optional[Union[int, str]] = None,
+) -> AttackAnalyticsResponse | CWAFErrorResponse:
+    """
+    Retrieve a list of Attack Analytics incidents for an account.
+
+    :param account_id: Account ID (required).
+    :param from_timestamp: Earliest time boundary in milliseconds since epoch (optional).
+    :param to_timestamp: Latest time boundary in milliseconds since epoch (optional).
+    """
+    logger.info("Fetching incidents for account %s", account_id)
+
+    try:
+        account_id_n = _to_int(account_id)
+        from_ts_n = _to_int(from_timestamp)
+        to_ts_n = _to_int(to_timestamp)
+    except Exception as e:
+        logger.error("Error parsing parameters for get_incidents_api: %s", e, exc_info=True)
+        return CWAFErrorResponse(
+            errors=[ApiError(status=400, title="Bad Request", detail="Invalid tool arguments")]
+        )
+
+    if not account_id_n:
+        return CWAFErrorResponse(
+            errors=[ApiError(status=400, title="Bad Request", detail="account_id is required")]
+        )
+
+    # Auto-convert seconds to milliseconds if timestamp looks like seconds (< 1e11)
+    if from_ts_n and from_ts_n < 100_000_000_000:
+        from_ts_n *= 1000
+    if to_ts_n and to_ts_n < 100_000_000_000:
+        to_ts_n *= 1000
+
+    params = {"caid": account_id_n}
+    if from_ts_n:
+        params["from_timestamp"] = from_ts_n
+    if to_ts_n:
+        params["to_timestamp"] = to_ts_n
+
+    url = BASE_ANALYTICS_URL + "/v1/incidents"
+    return await invoke_analytics_get_request(url, params, context)
+
+
+async def get_incident_sample_events_api(
+    account_id: Union[int, str],
+    incident_id: str,
+    context: Optional[Context] = None,
+) -> AttackAnalyticsResponse | CWAFErrorResponse:
+    """
+    Retrieve a sampling of events for a specific incident.
+
+    :param account_id: Account ID (required).
+    :param incident_id: The incident UUID (required).
+    """
+    logger.info("Fetching sample events for incident %s", incident_id)
+
+    try:
+        account_id_n = _to_int(account_id)
+    except Exception as e:
+        logger.error("Error parsing parameters for get_incident_sample_events_api: %s", e, exc_info=True)
+        return CWAFErrorResponse(
+            errors=[ApiError(status=400, title="Bad Request", detail="Invalid tool arguments")]
+        )
+
+    if not account_id_n:
+        return CWAFErrorResponse(
+            errors=[ApiError(status=400, title="Bad Request", detail="account_id is required")]
+        )
+    if not incident_id:
+        return CWAFErrorResponse(
+            errors=[ApiError(status=400, title="Bad Request", detail="incident_id is required")]
+        )
+
+    params = {"caid": account_id_n}
+    url = BASE_ANALYTICS_URL + f"/v1/incidents/{incident_id}/sample-events"
+    return await invoke_analytics_get_request(url, params, context)
+
+
+async def get_incident_stats_api(
+    account_id: Union[int, str],
+    incident_id: str,
+    context: Optional[Context] = None,
+) -> AttackAnalyticsResponse | CWAFErrorResponse:
+    """
+    Retrieve full details/statistics for a specific incident.
+
+    :param account_id: Account ID (required).
+    :param incident_id: The incident UUID (required).
+    """
+    logger.info("Fetching stats for incident %s", incident_id)
+
+    try:
+        account_id_n = _to_int(account_id)
+    except Exception as e:
+        logger.error("Error parsing parameters for get_incident_stats_api: %s", e, exc_info=True)
+        return CWAFErrorResponse(
+            errors=[ApiError(status=400, title="Bad Request", detail="Invalid tool arguments")]
+        )
+
+    if not account_id_n:
+        return CWAFErrorResponse(
+            errors=[ApiError(status=400, title="Bad Request", detail="account_id is required")]
+        )
+    if not incident_id:
+        return CWAFErrorResponse(
+            errors=[ApiError(status=400, title="Bad Request", detail="incident_id is required")]
+        )
+
+    params = {"caid": account_id_n}
+    url = BASE_ANALYTICS_URL + f"/v1/incidents/{incident_id}/stats"
+    return await invoke_analytics_get_request(url, params, context)
+
+
+async def get_insights_api(
+    account_id: Union[int, str],
+    context: Optional[Context] = None,
+) -> AttackAnalyticsResponse | CWAFErrorResponse:
+    """
+    Retrieve the list of insights (recommended actions) for an account.
+
+    :param account_id: Account ID (required).
+    """
+    logger.info("Fetching insights for account %s", account_id)
+
+    try:
+        account_id_n = _to_int(account_id)
+    except Exception as e:
+        logger.error("Error parsing parameters for get_insights_api: %s", e, exc_info=True)
+        return CWAFErrorResponse(
+            errors=[ApiError(status=400, title="Bad Request", detail="Invalid tool arguments")]
+        )
+
+    if not account_id_n:
+        return CWAFErrorResponse(
+            errors=[ApiError(status=400, title="Bad Request", detail="account_id is required")]
+        )
+
+    params = {"caid": account_id_n}
+    url = BASE_ANALYTICS_URL + "/v1/insights"
+    return await invoke_analytics_get_request(url, params, context)
 
 
 def get_site_from_response(r: dict) -> Site:

--- a/src/cwaf_external_mcp/model/attack_analytics_dto.py
+++ b/src/cwaf_external_mcp/model/attack_analytics_dto.py
@@ -1,0 +1,199 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Attack Analytics DTOs."""
+
+from typing import Any, List, Optional
+
+from pydantic import BaseModel
+
+
+class AttackedSiteInfo(BaseModel):
+    """Information about an attacked site."""
+
+    site_id: Optional[int] = None
+    site_name: Optional[str] = None
+
+
+class CountryDominance(BaseModel):
+    """Dominance information for a country."""
+
+    dominance: Optional[str] = None
+    country: Optional[str] = None
+    countryCode: Optional[str] = None
+
+
+class IpDominance(BaseModel):
+    """Dominance information for an IP address."""
+
+    dominance: Optional[str] = None
+    ip: Optional[str] = None
+    reputation: Optional[List[str]] = None
+
+
+class ToolDominance(BaseModel):
+    """Dominance information for an attack tool."""
+
+    dominance: Optional[str] = None
+    name: Optional[str] = None
+    type: Optional[str] = None
+
+
+class ShinyObject(BaseModel):
+    """Dominant value object."""
+
+    dominance: Optional[str] = None
+    value: Optional[str] = None
+
+
+class DdosData(BaseModel):
+    """DDoS-specific attack data."""
+
+    max_BPS_passed: Optional[float] = None
+    max_BPS_blocked: Optional[float] = None
+    network_traffic_data_list: Optional[List[dict]] = None
+
+
+class Incident(BaseModel):
+    """Single attack analytics incident."""
+
+    id: Optional[str] = None
+    main_sentence: Optional[str] = None
+    secondary_sentence: Optional[str] = None
+    false_positive: Optional[bool] = None
+    events_count: Optional[int] = None
+    events_blocked_percent: Optional[int] = None
+    first_event_time: Optional[int] = None
+    last_event_time: Optional[int] = None
+    severity: Optional[str] = None
+    severity_explanation: Optional[str] = None
+    dominant_attack_country: Optional[CountryDominance] = None
+    dominant_attack_ip: Optional[IpDominance] = None
+    dominant_attacked_host: Optional[ShinyObject] = None
+    dominant_attack_tool: Optional[ToolDominance] = None
+    dominant_attack_violation: Optional[str] = None
+    only_custom_rule_based: Optional[bool] = None
+    how_common: Optional[str] = None
+    incident_type: Optional[str] = None
+    ddos_data: Optional[DdosData] = None
+
+
+class Violation(BaseModel):
+    """A single WAF rule violation."""
+
+    rule_description: Optional[str] = None
+    action: Optional[str] = None
+    violation_context: Optional[str] = None
+
+
+class Cookie(BaseModel):
+    """HTTP cookie data."""
+
+    name: Optional[str] = None
+    value: Optional[str] = None
+    domain: Optional[str] = None
+    expiration: Optional[str] = None
+    path: Optional[str] = None
+    persistent: Optional[bool] = None
+    secure: Optional[bool] = None
+    traceability: Optional[str] = None
+
+
+class Event(BaseModel):
+    """Single event that participated in an attack."""
+
+    event_id: Optional[int] = None
+    method: Optional[str] = None
+    host: Optional[str] = None
+    query_string: Optional[str] = None
+    url_path: Optional[str] = None
+    response_code: Optional[str] = None
+    session_id: Optional[str] = None
+    main_client_ip: Optional[str] = None
+    country_code: Optional[List[str]] = None
+    client_application: Optional[str] = None
+    declared_client_application: Optional[str] = None
+    destination_ip: Optional[str] = None
+    referrer: Optional[str] = None
+    is_event_blocked: Optional[bool] = None
+    violations: Optional[List[Violation]] = None
+    headers: Optional[List[dict]] = None
+    cookies: Optional[List[Cookie]] = None
+    reporter: Optional[str] = None
+    creation_time: Optional[str] = None
+
+
+class IncidentStats(BaseModel):
+    """Full statistics for a single incident."""
+
+    id: Optional[str] = None
+    events_count: Optional[int] = None
+    blocked_events_timeseries: Optional[List[dict]] = None
+    alerted_events_timeseries: Optional[List[dict]] = None
+    attack_ips: Optional[List[dict]] = None
+    attack_agents: Optional[List[dict]] = None
+    attack_tools: Optional[List[dict]] = None
+    attack_tool_types: Optional[List[dict]] = None
+    violations_blocked: Optional[List[dict]] = None
+    violations_alerted: Optional[List[dict]] = None
+    attack_urls: Optional[List[dict]] = None
+    attacked_hosts: Optional[List[dict]] = None
+    attack_class_c: Optional[List[dict]] = None
+    attack_geolocations: Optional[List[dict]] = None
+    waf_origins_of_alerts: Optional[List[dict]] = None
+    waf_origins_of_blocks: Optional[List[dict]] = None
+    waf_origins_entities: Optional[List[dict]] = None
+    rules_list: Optional[List[dict]] = None
+    associated_cve: Optional[List[str]] = None
+
+
+class GeneralInsightData(BaseModel):
+    """General data for an insight."""
+
+    attacked_site_info: Optional[AttackedSiteInfo] = None
+    status: Optional[str] = None
+    snoozedUntil: Optional[int] = None
+
+
+class Insight(BaseModel):
+    """A single insight entry for a vulnerable site."""
+
+    type: Optional[str] = None
+    insightDetails: Optional[GeneralInsightData] = None
+    additionalDetails: Optional[dict] = None
+
+
+class InsightSummaryVOApi(BaseModel):
+    """Summary of a single insight recommendation."""
+
+    type: Optional[str] = None
+    mainSentence: Optional[str] = None
+    secondarySentence: Optional[str] = None
+    moreInfo: Optional[str] = None
+    recommendation: Optional[str] = None
+    vulnerableSites: Optional[List[Insight]] = None
+    timestamp: Optional[str] = None
+    additionalDetails: Optional[dict] = None
+
+
+class InsightsDataApi(BaseModel):
+    """Container for a list of insight summaries."""
+
+    insights: Optional[List[InsightSummaryVOApi]] = None
+
+
+class AttackAnalyticsResponse(BaseModel):
+    """Response wrapper for Attack Analytics API calls."""
+
+    data: Any

--- a/src/cwaf_external_mcp/server.py
+++ b/src/cwaf_external_mcp/server.py
@@ -33,7 +33,12 @@ from cwaf_external_mcp.mcp_tools.cwaf_tools import (
     get_site_domains_api,
     get_polices_of_account_by_filter_api,
     get_rules_api,
+    get_incidents_api,
+    get_incident_sample_events_api,
+    get_incident_stats_api,
+    get_insights_api,
 )
+from cwaf_external_mcp.model.attack_analytics_dto import AttackAnalyticsResponse
 from cwaf_external_mcp.model.cwaf_error_response import CWAFErrorResponse
 from cwaf_external_mcp.model.cwaf_response import CWAFResponse
 from cwaf_external_mcp.utilities.logging import get_logger
@@ -425,6 +430,217 @@ async def get_sites_details_of_a_given_account_tool(
         sub_account_ids=sub_account_ids,
         page_num=page_num,
         page_size=page_size,
+        context=context,
+    )
+
+
+@cwaf_mcp.tool()
+async def get_incidents_tool(
+    context: Context,
+    account_id: Union[int, str],
+    from_timestamp: Optional[Union[int, str]] = None,
+    to_timestamp: Optional[Union[int, str]] = None,
+    days_back: Optional[int] = None,
+) -> AttackAnalyticsResponse | CWAFErrorResponse:
+    """
+    Retrieve a list of Attack Analytics incidents for an account during a specified time period.
+
+    Parameters:
+        account_id (int): Unique identifier of the account to operate on. (Required)
+        days_back (int): Optional. Number of days to look back from now. Use this instead of
+            from_timestamp/to_timestamp when the user asks for "last N days" or "last N hours".
+            Example: days_back=7 returns incidents from the last 7 days.
+            days_back=30 returns incidents from the last 30 days.
+        from_timestamp (int): Optional. Earliest time boundary, specified as number of milliseconds
+            since midnight 1970 (UNIX time * 1000). Ignored if days_back is provided.
+            If omitted, returns all available incidents.
+        to_timestamp (int): Optional. Latest time boundary, specified as number of milliseconds
+            since midnight 1970 (UNIX time * 1000). Ignored if days_back is provided.
+
+    Returns:
+        On success: AttackAnalyticsResponse with data containing a list of Incident objects:
+            Incident:{
+                id: str --> Unique incident identifier (UUID).
+                main_sentence: str --> Short description of the attack.
+                secondary_sentence: str --> Secondary sentence with more details.
+                false_positive: bool --> Whether the incident is a false positive.
+                events_count: int --> Number of HTTP events that participated in the attack.
+                events_blocked_percent: int --> Percentage of events blocked by Imperva.
+                first_event_time: int --> Timestamp (ms) of first event in the attack.
+                last_event_time: int --> Timestamp (ms) of last event in the attack.
+                severity: str --> Attack severity: CRITICAL, MAJOR, MINOR, or CUSTOM.
+                severity_explanation: str --> Explanation of the severity rating.
+                dominant_attack_country: CountryDominance --> Country that sent more than 50% of attacks.
+                dominant_attack_ip: IpDominance --> IP that sent more than 50% of attacks.
+                dominant_attacked_host: ShinyObject --> Host attacked by more than 50% of events.
+                dominant_attack_tool: ToolDominance --> Tool used in more than 50% of attacks.
+                dominant_attack_violation: str --> Violation in more than 50% of attacks.
+                only_custom_rule_based: bool --> True if all events were from user-defined rules.
+                how_common: str --> Whether this incident was spotted on other Imperva customers.
+                incident_type: str --> "REGULAR" or "DDOS".
+                ddos_data: DdosData --> Additional information for DDoS incidents.
+            }
+
+        On failure: a list of ApiError objects:
+            ApiError:{
+                status: int --> The HTTP status code of the error.
+                title: str --> A brief title describing the error.
+                detail: Optional[str] --> A detailed description of the error, if available.
+            }
+    """
+    import time as _time
+    if days_back is not None:
+        now_ms = int(_time.time() * 1000)
+        from_timestamp = now_ms - days_back * 86400 * 1000
+        to_timestamp = now_ms
+
+    return await get_incidents_api(
+        account_id=account_id,
+        from_timestamp=from_timestamp,
+        to_timestamp=to_timestamp,
+        context=context,
+    )
+
+
+@cwaf_mcp.tool()
+async def get_incident_sample_events_tool(
+    context: Context,
+    account_id: Union[int, str],
+    incident_id: str,
+) -> AttackAnalyticsResponse | CWAFErrorResponse:
+    """
+    Retrieve a sampling of events that participated in a specific incident.
+
+    Parameters:
+        account_id (int): Unique identifier of the account to operate on. (Required)
+        incident_id (str): The incident identifier (UUID). (Required)
+
+    Returns:
+        On success: AttackAnalyticsResponse with data containing an Event object:
+            Event:{
+                event_id: int --> Id of the event.
+                method: str --> HTTP method (e.g. GET, POST).
+                host: str --> The host that this request was sent to.
+                query_string: str --> Query string arguments sent with the request.
+                url_path: str --> Path that this request accessed.
+                response_code: str --> HTTP response code.
+                session_id: str --> Id of the request session.
+                main_client_ip: str --> IP address identified as the request source.
+                country_code: list[str] --> Two-digit country codes the request was sent from.
+                client_application: str --> Application identified by Imperva as the sender.
+                declared_client_application: str --> Application declared as the sender.
+                destination_ip: str --> IP address the event was sent to.
+                referrer: str --> Referrer URI of the request.
+                is_event_blocked: bool --> Whether this event was blocked by Imperva WAF.
+                violations: list[Violation] --> Violations associated with this request.
+                headers: list[dict] --> HTTP headers in this request.
+                cookies: list[Cookie] --> Cookies passed in the request.
+                reporter: str --> Imperva WAF system that reported this request.
+                creation_time: str --> Time when this event occurred (ms since epoch).
+            }
+
+        On failure: a list of ApiError objects:
+            ApiError:{
+                status: int --> The HTTP status code of the error.
+                title: str --> A brief title describing the error.
+                detail: Optional[str] --> A detailed description of the error, if available.
+            }
+    """
+    return await get_incident_sample_events_api(
+        account_id=account_id,
+        incident_id=incident_id,
+        context=context,
+    )
+
+
+@cwaf_mcp.tool()
+async def get_incident_stats_tool(
+    context: Context,
+    account_id: Union[int, str],
+    incident_id: str,
+) -> AttackAnalyticsResponse | CWAFErrorResponse:
+    """
+    Retrieve full details and statistics for a specific incident.
+
+    Parameters:
+        account_id (int): Unique identifier of the account to operate on. (Required)
+        incident_id (str): The incident identifier (UUID). (Required)
+
+    Returns:
+        On success: AttackAnalyticsResponse with data containing an IncidentStats object:
+            IncidentStats:{
+                id: str --> Unique incident identifier.
+                events_count: int --> Number of HTTP events in the attack.
+                blocked_events_timeseries: list --> Timeseries of blocked event counts.
+                alerted_events_timeseries: list --> Timeseries of alerted event counts.
+                attack_ips: list --> IP addresses that participated in the attack.
+                attack_agents: list --> User-agents that participated in the attack.
+                attack_tools: list --> Tools used in the attack.
+                attack_tool_types: list --> Tool types used in the attack.
+                violations_blocked: list --> Blocked violations identified in the incident.
+                violations_alerted: list --> Alerted violations identified in the incident.
+                attack_urls: list --> URLs attacked during this incident.
+                attacked_hosts: list --> Hosts attacked during this incident.
+                attack_class_c: list --> Class C subnets that participated in the attack.
+                attack_geolocations: list --> Geographical areas that events came from.
+                waf_origins_of_alerts: list --> WAF servers that alerted events.
+                waf_origins_of_blocks: list --> WAF servers that blocked events.
+                waf_origins_entities: list --> WAF servers that events came through.
+                rules_list: list --> Rules that triggered this incident.
+                associated_cve: list[str] --> Known CVEs associated with this incident.
+            }
+
+        On failure: a list of ApiError objects:
+            ApiError:{
+                status: int --> The HTTP status code of the error.
+                title: str --> A brief title describing the error.
+                detail: Optional[str] --> A detailed description of the error, if available.
+            }
+    """
+    return await get_incident_stats_api(
+        account_id=account_id,
+        incident_id=incident_id,
+        context=context,
+    )
+
+
+@cwaf_mcp.tool()
+async def get_insights_tool(
+    context: Context,
+    account_id: Union[int, str],
+) -> AttackAnalyticsResponse | CWAFErrorResponse:
+    """
+    Retrieve the list of insights for an account — recommended actions based on attacks
+    that have targeted the account's sites and applications.
+
+    Parameters:
+        account_id (int): Unique identifier of the account to operate on. (Required)
+
+    Returns:
+        On success: AttackAnalyticsResponse with data containing a list of InsightsDataApi objects:
+            InsightsDataApi:{
+                insights: list[InsightSummaryVOApi] --> List of insight summaries.
+            }
+            InsightSummaryVOApi:{
+                type: str --> Type of insight.
+                mainSentence: str --> Main description of the insight.
+                secondarySentence: str --> Secondary description with more details.
+                moreInfo: str --> Additional information.
+                recommendation: str --> Recommended action to take.
+                vulnerableSites: list[Insight] --> Sites affected by this insight.
+                timestamp: str --> Timestamp of when the insight was generated.
+                additionalDetails: dict --> Extra details specific to this insight type.
+            }
+
+        On failure: a list of ApiError objects:
+            ApiError:{
+                status: int --> The HTTP status code of the error.
+                title: str --> A brief title describing the error.
+                detail: Optional[str] --> A detailed description of the error, if available.
+            }
+    """
+    return await get_insights_api(
+        account_id=account_id,
         context=context,
     )
 

--- a/tests/test_attack_analytics.py
+++ b/tests/test_attack_analytics.py
@@ -1,0 +1,385 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from unittest import mock
+
+import cwaf_external_mcp.mcp_tools.cwaf_tools as cwaf_tools
+from cwaf_external_mcp.model.attack_analytics_dto import (
+    AttackAnalyticsResponse,
+    Incident,
+    Event,
+    IncidentStats,
+    InsightsDataApi,
+)
+
+
+@pytest.fixture(autouse=True)
+def patch_env(monkeypatch):
+    monkeypatch.setenv("API_ID", "123")
+    monkeypatch.setenv("API_KEY", "abc")
+
+
+# ---------------------------------------------------------------------------
+# invoke_analytics_get_request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invoke_analytics_get_request_success(monkeypatch):
+    mock_client = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status = 200
+    mock_response.json = mock.AsyncMock(return_value=[{"id": "abc"}])
+    monkeypatch.setattr(cwaf_tools, "get_async_client", lambda: mock_client)
+    mock_client.get.return_value = mock_response
+
+    result = await cwaf_tools.invoke_analytics_get_request("http://test/url", {})
+
+    assert isinstance(result, AttackAnalyticsResponse)
+    assert result.data == [{"id": "abc"}]
+
+
+@pytest.mark.asyncio
+async def test_invoke_analytics_get_request_http_error(monkeypatch):
+    mock_client = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status = 403
+    mock_response.json = mock.AsyncMock(return_value={"message": "Forbidden"})
+    monkeypatch.setattr(cwaf_tools, "get_async_client", lambda: mock_client)
+    mock_client.get.return_value = mock_response
+
+    result = await cwaf_tools.invoke_analytics_get_request("http://test/url", {})
+
+    assert hasattr(result, "errors")
+    assert result.errors[0].status == 403
+    assert result.errors[0].detail == "Forbidden"
+
+
+@pytest.mark.asyncio
+async def test_invoke_analytics_get_request_exception(monkeypatch):
+    mock_client = mock.AsyncMock()
+    mock_client.get.side_effect = Exception("connection error")
+    monkeypatch.setattr(cwaf_tools, "get_async_client", lambda: mock_client)
+
+    result = await cwaf_tools.invoke_analytics_get_request("http://test/url", {})
+
+    assert hasattr(result, "errors")
+    assert result.errors[0].status == 500
+
+
+# ---------------------------------------------------------------------------
+# get_incidents_api
+# ---------------------------------------------------------------------------
+
+INCIDENT_PAYLOAD = [
+    {
+        "id": "ad2c8f40-3e82-11e9-354e-b114829e37eb",
+        "main_sentence": "Bad Bots attack from United States",
+        "secondary_sentence": "On host acme.com",
+        "false_positive": False,
+        "events_count": 520,
+        "events_blocked_percent": 20,
+        "first_event_time": 1548073343000,
+        "last_event_time": 1548073399000,
+        "severity": "MINOR",
+        "severity_explanation": "Highly targeted",
+        "incident_type": "REGULAR",
+    }
+]
+
+
+@pytest.mark.asyncio
+async def test_get_incidents_api_success(monkeypatch):
+    mock_client = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status = 200
+    mock_response.json = mock.AsyncMock(return_value=INCIDENT_PAYLOAD)
+    monkeypatch.setattr(cwaf_tools, "get_async_client", lambda: mock_client)
+    mock_client.get.return_value = mock_response
+
+    result = await cwaf_tools.get_incidents_api(account_id=12345)
+
+    assert isinstance(result, AttackAnalyticsResponse)
+    assert result.data == INCIDENT_PAYLOAD
+
+
+@pytest.mark.asyncio
+async def test_get_incidents_api_with_timestamps(monkeypatch):
+    mock_client = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status = 200
+    mock_response.json = mock.AsyncMock(return_value=INCIDENT_PAYLOAD)
+    monkeypatch.setattr(cwaf_tools, "get_async_client", lambda: mock_client)
+    mock_client.get.return_value = mock_response
+
+    result = await cwaf_tools.get_incidents_api(
+        account_id=12345,
+        from_timestamp=1548073343000,
+        to_timestamp=1548073999000,
+    )
+
+    assert isinstance(result, AttackAnalyticsResponse)
+    call_params = mock_client.get.call_args[1]["params"]
+    assert call_params["from_timestamp"] == 1548073343000
+    assert call_params["to_timestamp"] == 1548073999000
+
+
+@pytest.mark.asyncio
+async def test_get_incidents_api_missing_account_id(monkeypatch):
+    result = await cwaf_tools.get_incidents_api(account_id=None)
+
+    assert hasattr(result, "errors")
+    assert result.errors[0].status == 400
+
+
+@pytest.mark.asyncio
+async def test_get_incidents_api_invalid_args(monkeypatch):
+    monkeypatch.setattr(cwaf_tools, "_to_int", lambda x: int("fail"))
+    result = await cwaf_tools.get_incidents_api(account_id="bad")
+
+    assert hasattr(result, "errors")
+    assert result.errors[0].status == 400
+
+
+# ---------------------------------------------------------------------------
+# get_incident_sample_events_api
+# ---------------------------------------------------------------------------
+
+SAMPLE_EVENTS_PAYLOAD = {
+    "event_id": 123,
+    "method": "GET",
+    "host": "www.acme.com",
+    "url_path": "/admin/login",
+    "is_event_blocked": True,
+}
+
+
+@pytest.mark.asyncio
+async def test_get_incident_sample_events_api_success(monkeypatch):
+    mock_client = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status = 200
+    mock_response.json = mock.AsyncMock(return_value=SAMPLE_EVENTS_PAYLOAD)
+    monkeypatch.setattr(cwaf_tools, "get_async_client", lambda: mock_client)
+    mock_client.get.return_value = mock_response
+
+    result = await cwaf_tools.get_incident_sample_events_api(
+        account_id=12345,
+        incident_id="ad2c8f40-3e82-11e9-354e-b114829e37eb",
+    )
+
+    assert isinstance(result, AttackAnalyticsResponse)
+    assert result.data == SAMPLE_EVENTS_PAYLOAD
+    called_url = mock_client.get.call_args[0][0]
+    assert "ad2c8f40-3e82-11e9-354e-b114829e37eb" in called_url
+    assert "sample-events" in called_url
+
+
+@pytest.mark.asyncio
+async def test_get_incident_sample_events_api_missing_account_id(monkeypatch):
+    result = await cwaf_tools.get_incident_sample_events_api(
+        account_id=None,
+        incident_id="some-uuid",
+    )
+
+    assert hasattr(result, "errors")
+    assert result.errors[0].status == 400
+
+
+@pytest.mark.asyncio
+async def test_get_incident_sample_events_api_missing_incident_id(monkeypatch):
+    result = await cwaf_tools.get_incident_sample_events_api(
+        account_id=12345,
+        incident_id="",
+    )
+
+    assert hasattr(result, "errors")
+    assert result.errors[0].status == 400
+
+
+@pytest.mark.asyncio
+async def test_get_incident_sample_events_api_invalid_args(monkeypatch):
+    monkeypatch.setattr(cwaf_tools, "_to_int", lambda x: int("fail"))
+    result = await cwaf_tools.get_incident_sample_events_api(
+        account_id="bad",
+        incident_id="some-uuid",
+    )
+
+    assert hasattr(result, "errors")
+    assert result.errors[0].status == 400
+
+
+# ---------------------------------------------------------------------------
+# get_incident_stats_api
+# ---------------------------------------------------------------------------
+
+INCIDENT_STATS_PAYLOAD = {
+    "id": "ad2c8f40-3e82-11e9-354e-b114829e37eb",
+    "events_count": 520,
+    "attack_ips": [{"key": {"ip": "10.0.0.1"}, "value": 100}],
+    "attack_urls": [{"key": "/admin.php", "value": 5}],
+    "associated_cve": ["CVE-2020-8417"],
+}
+
+
+@pytest.mark.asyncio
+async def test_get_incident_stats_api_success(monkeypatch):
+    mock_client = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status = 200
+    mock_response.json = mock.AsyncMock(return_value=INCIDENT_STATS_PAYLOAD)
+    monkeypatch.setattr(cwaf_tools, "get_async_client", lambda: mock_client)
+    mock_client.get.return_value = mock_response
+
+    result = await cwaf_tools.get_incident_stats_api(
+        account_id=12345,
+        incident_id="ad2c8f40-3e82-11e9-354e-b114829e37eb",
+    )
+
+    assert isinstance(result, AttackAnalyticsResponse)
+    assert result.data == INCIDENT_STATS_PAYLOAD
+    called_url = mock_client.get.call_args[0][0]
+    assert "stats" in called_url
+
+
+@pytest.mark.asyncio
+async def test_get_incident_stats_api_missing_account_id(monkeypatch):
+    result = await cwaf_tools.get_incident_stats_api(
+        account_id=None,
+        incident_id="some-uuid",
+    )
+
+    assert hasattr(result, "errors")
+    assert result.errors[0].status == 400
+
+
+@pytest.mark.asyncio
+async def test_get_incident_stats_api_missing_incident_id(monkeypatch):
+    result = await cwaf_tools.get_incident_stats_api(
+        account_id=12345,
+        incident_id="",
+    )
+
+    assert hasattr(result, "errors")
+    assert result.errors[0].status == 400
+
+
+@pytest.mark.asyncio
+async def test_get_incident_stats_api_invalid_args(monkeypatch):
+    monkeypatch.setattr(cwaf_tools, "_to_int", lambda x: int("fail"))
+    result = await cwaf_tools.get_incident_stats_api(
+        account_id="bad",
+        incident_id="some-uuid",
+    )
+
+    assert hasattr(result, "errors")
+    assert result.errors[0].status == 400
+
+
+# ---------------------------------------------------------------------------
+# get_insights_api
+# ---------------------------------------------------------------------------
+
+INSIGHTS_PAYLOAD = [
+    {
+        "insights": [
+            {
+                "type": "BAD_BOTS",
+                "mainSentence": "You have bad bot activity",
+                "secondarySentence": "On 3 sites",
+                "moreInfo": "More info here",
+                "recommendation": "Enable Bot Protection",
+                "vulnerableSites": [],
+                "timestamp": "2024-01-01T00:00:00Z",
+                "additionalDetails": {},
+            }
+        ]
+    }
+]
+
+
+@pytest.mark.asyncio
+async def test_get_insights_api_success(monkeypatch):
+    mock_client = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status = 200
+    mock_response.json = mock.AsyncMock(return_value=INSIGHTS_PAYLOAD)
+    monkeypatch.setattr(cwaf_tools, "get_async_client", lambda: mock_client)
+    mock_client.get.return_value = mock_response
+
+    result = await cwaf_tools.get_insights_api(account_id=12345)
+
+    assert isinstance(result, AttackAnalyticsResponse)
+    assert result.data == INSIGHTS_PAYLOAD
+    called_url = mock_client.get.call_args[0][0]
+    assert "insights" in called_url
+
+
+@pytest.mark.asyncio
+async def test_get_insights_api_missing_account_id(monkeypatch):
+    result = await cwaf_tools.get_insights_api(account_id=None)
+
+    assert hasattr(result, "errors")
+    assert result.errors[0].status == 400
+
+
+@pytest.mark.asyncio
+async def test_get_insights_api_invalid_args(monkeypatch):
+    monkeypatch.setattr(cwaf_tools, "_to_int", lambda x: int("fail"))
+    result = await cwaf_tools.get_insights_api(account_id="bad")
+
+    assert hasattr(result, "errors")
+    assert result.errors[0].status == 400
+
+
+# ---------------------------------------------------------------------------
+# DTO model validation
+# ---------------------------------------------------------------------------
+
+
+def test_incident_model_optional_fields():
+    incident = Incident(id="test-uuid")
+    assert incident.id == "test-uuid"
+    assert incident.severity is None
+    assert incident.ddos_data is None
+
+
+def test_event_model_optional_fields():
+    event = Event(event_id=1, method="GET", host="example.com")
+    assert event.event_id == 1
+    assert event.violations is None
+    assert event.cookies is None
+
+
+def test_incident_stats_model_optional_fields():
+    stats = IncidentStats(id="test-uuid", events_count=100)
+    assert stats.events_count == 100
+    assert stats.associated_cve is None
+    assert stats.attack_ips is None
+
+
+def test_insights_data_api_model():
+    insights = InsightsDataApi(insights=[])
+    assert insights.insights == []
+
+
+def test_attack_analytics_response_wraps_list():
+    response = AttackAnalyticsResponse(data=[{"id": "1"}, {"id": "2"}])
+    assert len(response.data) == 2
+
+
+def test_attack_analytics_response_wraps_dict():
+    response = AttackAnalyticsResponse(data={"id": "abc", "events_count": 10})
+    assert response.data["id"] == "abc"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -55,6 +55,11 @@ def test_server_module_loads_correctly():
     assert hasattr(server_module, "get_polices_of_account_by_filter_tool")
     assert hasattr(server_module, "get_domains_by_filters_tool")
     assert hasattr(server_module, "get_sites_details_of_a_given_account_tool")
+    # Attack Analytics tools
+    assert hasattr(server_module, "get_incidents_tool")
+    assert hasattr(server_module, "get_incident_sample_events_tool")
+    assert hasattr(server_module, "get_incident_stats_tool")
+    assert hasattr(server_module, "get_insights_tool")
 
 
 def test_server_port_constant():


### PR DESCRIPTION
## Summary
- Add 4 new MCP tools for Imperva Attack Analytics API
- `get_incidents_tool` — list attack incidents with time filter (days_back, from/to timestamp)
- `get_incident_sample_events_tool` — get sample HTTP events for an incident
- `get_incident_stats_tool` — get full statistics for an incident
- `get_insights_tool` — get security insights and recommendations

## New files
- `src/cwaf_external_mcp/model/attack_analytics_dto.py` — Pydantic models
- `tests/test_attack_analytics.py` — 24 test cases

## API Reference
Based on Imperva Attack Analytics API (`api.imperva.com/analytics`)

## Test plan
- [ ] `uv run pytest tests/test_attack_analytics.py tests/test_server.py -v`
- [ ] Manual test via Claude Desktop with real account